### PR TITLE
WPFアプリをMVVM/DI構成でレイヤー分割・リファクタ

### DIFF
--- a/WpfBingo/App.xaml.cs
+++ b/WpfBingo/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using WpfBingo.Hosting;
 
 namespace WpfBingo;
 
@@ -19,11 +20,8 @@ public partial class App : Application
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>
             {
-                // ViewModel をシングルトン登録
-                services.AddSingleton<BingoViewModel>();
-
-                // MainWindow をトランジェントで登録（必要に応じてシングルトンに変更可）
-                services.AddTransient<MainWindow>();
+                services.AddWpfBingoServices();
+                services.AddHostedService<WpfHostedService>();
             })
             .Build();
     }
@@ -37,10 +35,6 @@ public partial class App : Application
     protected override async void OnStartup(StartupEventArgs e)
     {
         await _host.StartAsync();
-
-        var mainWindow = _host.Services.GetRequiredService<MainWindow>();
-        mainWindow.Show();
-
         base.OnStartup(e);
     }
 

--- a/WpfBingo/Hosting/ServiceCollectionExtensions.cs
+++ b/WpfBingo/Hosting/ServiceCollectionExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using WpfBingo.ViewModels;
+using WpfBingo.Views;
+
+namespace WpfBingo.Hosting;
+
+/// <summary>
+/// DI コンテナへのサービス登録を拡張するメソッド群です。
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// アプリケーションで使用する ViewModel を登録します。
+    /// </summary>
+    /// <param name="services">サービスコレクション。</param>
+    /// <returns>チェーン呼び出し用のサービスコレクション。</returns>
+    public static IServiceCollection AddViewModels(this IServiceCollection services)
+    {
+        services.AddSingleton<BingoViewModel>();
+        return services;
+    }
+
+    /// <summary>
+    /// アプリケーションで使用する View（ウィンドウ）を登録します。
+    /// </summary>
+    /// <param name="services">サービスコレクション。</param>
+    /// <returns>チェーン呼び出し用のサービスコレクション。</returns>
+    public static IServiceCollection AddViews(this IServiceCollection services)
+    {
+        services.AddTransient<MainWindow>();
+        return services;
+    }
+
+    /// <summary>
+    /// アプリケーションの全サービスを一括登録します。
+    /// </summary>
+    /// <param name="services">サービスコレクション。</param>
+    /// <returns>チェーン呼び出し用のサービスコレクション。</returns>
+    public static IServiceCollection AddWpfBingoServices(this IServiceCollection services)
+    {
+        services.AddViewModels();
+        services.AddViews();
+        return services;
+    }
+}

--- a/WpfBingo/Hosting/WpfHostedService.cs
+++ b/WpfBingo/Hosting/WpfHostedService.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using WpfBingo.Views;
+
+namespace WpfBingo.Hosting;
+
+/// <summary>
+/// WPF アプリケーションのライフサイクルを管理する HostedService です。
+/// </summary>
+/// <param name="serviceProvider">DI コンテナのサービスプロバイダー。</param>
+public sealed class WpfHostedService(IServiceProvider serviceProvider) : IHostedService
+{
+    private MainWindow? _mainWindow;
+
+    /// <summary>
+    /// ホスト開始時にメインウィンドウを表示します。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _mainWindow = serviceProvider.GetRequiredService<MainWindow>();
+        _mainWindow.Show();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// ホスト停止時のクリーンアップを行います。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _mainWindow?.Close();
+        return Task.CompletedTask;
+    }
+}

--- a/WpfBingo/Models/BingoModels.cs
+++ b/WpfBingo/Models/BingoModels.cs
@@ -1,0 +1,60 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace WpfBingo.Models;
+
+/// <summary>
+/// 単一のビンゴ番号と抽選状態を表すモデル。
+/// </summary>
+/// <param name="value">ビンゴ番号。</param>
+public class BingoNumber(int value) : INotifyPropertyChanged
+{
+    private bool _isDrawn;
+
+    /// <summary>番号の数値。</summary>
+    public int Value { get; } = value;
+
+    /// <summary>抽選済みかどうか。</summary>
+    public bool IsDrawn
+    {
+        get => _isDrawn;
+        set
+        {
+            if (_isDrawn == value) return;
+            _isDrawn = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>プロパティ変更通知を送信します。</summary>
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+/// <summary>
+/// 10刻みの番号グループを表します。
+/// </summary>
+public class BingoNumberGroup
+{
+    /// <summary>グループを識別するラベル。</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>所属する番号リスト。</summary>
+    public ObservableCollection<BingoNumber> Numbers { get; } = [];
+}
+
+/// <summary>
+/// 列単位で番号を保持するモデル。
+/// </summary>
+public class BingoNumberColumn
+{
+    /// <summary>列のラベル (範囲や BINGO 文字)。</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>列に含まれる番号。</summary>
+    public ObservableCollection<BingoNumber> Numbers { get; } = [];
+}

--- a/WpfBingo/ViewModels/BingoViewModel.cs
+++ b/WpfBingo/ViewModels/BingoViewModel.cs
@@ -2,8 +2,9 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using WpfBingo.Models;
 
-namespace WpfBingo;
+namespace WpfBingo.ViewModels;
 
 /// <summary>
 /// ビンゴ抽選機の状態と UI 更新を司るメイン ViewModel。
@@ -14,10 +15,11 @@ public class BingoViewModel : INotifyPropertyChanged
     private readonly List<int> _availableNumbers = [];
     private int? _currentNumber;
     private string _currentNumberDisplay = "?";
-    private double _currentNumberFontSize = 120; // responsive font size
+    private double _currentNumberFontSize = 120;
     private int _rowsPerColumn = 10;
     private double _numberCellSize = 40;
     private double _numberFontSize = 16;
+    private bool _isDrawing;
 
     /// <summary>
     /// ViewModel を初期化し、コマンドと番号リストをセットアップします。
@@ -36,12 +38,16 @@ public class BingoViewModel : INotifyPropertyChanged
 
     /// <summary>抽選済み番号の履歴（新しい順）。</summary>
     public ObservableCollection<int> DrawnNumbers { get; }
+
     /// <summary>1～75 の全ビンゴ番号。</summary>
     public ObservableCollection<BingoNumber> AllNumbers { get; }
+
     /// <summary>10刻みのグループ表示用コレクション。</summary>
     public ObservableCollection<BingoNumberGroup> GroupedNumbers { get; }
+
     /// <summary>BINGO 列（1-15,16-30...）の静的コレクション。</summary>
     public ObservableCollection<BingoNumberColumn> Columns { get; }
+
     /// <summary>画面幅に応じて行数が変わる動的列。</summary>
     public ObservableCollection<BingoNumberColumn> DynamicColumns { get; } = [];
 
@@ -67,9 +73,37 @@ public class BingoViewModel : INotifyPropertyChanged
     }
 
     /// <summary>番号セルの一辺サイズ。</summary>
-    public double NumberCellSize { get => _numberCellSize; private set { if (Math.Abs(_numberCellSize - value) < 0.5) return; _numberCellSize = value; OnPropertyChanged(); } }
+    public double NumberCellSize
+    {
+        get => _numberCellSize;
+        private set { if (Math.Abs(_numberCellSize - value) < 0.5) return; _numberCellSize = value; OnPropertyChanged(); }
+    }
+
     /// <summary>セル内のフォントサイズ。</summary>
-    public double NumberFontSize { get => _numberFontSize; private set { if (Math.Abs(_numberFontSize - value) < 0.5) return; _numberFontSize = value; OnPropertyChanged(); } }
+    public double NumberFontSize
+    {
+        get => _numberFontSize;
+        private set { if (Math.Abs(_numberFontSize - value) < 0.5) return; _numberFontSize = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>抽選中かどうかを示すフラグ。</summary>
+    public bool IsDrawing
+    {
+        get => _isDrawing;
+        set
+        {
+            if (_isDrawing == value) return;
+            _isDrawing = value;
+            OnPropertyChanged();
+            ((RelayCommand)DrawNumberCommand).RaiseCanExecuteChanged();
+        }
+    }
+
+    /// <summary>番号を一つ抽選するためのコマンド。</summary>
+    public ICommand DrawNumberCommand { get; }
+
+    /// <summary>状態を初期化するコマンド。</summary>
+    public ICommand ResetCommand { get; }
 
     /// <summary>
     /// 中央番号エリアのサイズに合わせてフォントサイズを調整します。
@@ -81,24 +115,6 @@ public class BingoViewModel : INotifyPropertyChanged
         var minSide = Math.Min(width, height);
         var newSize = Math.Clamp(minSide * 0.55, 60, 320);
         CurrentNumberFontSize = newSize;
-    }
-
-    /// <summary>番号を一つ抽選するためのコマンド。</summary>
-    public ICommand DrawNumberCommand { get; }
-    /// <summary>状態を初期化するコマンド。</summary>
-    public ICommand ResetCommand { get; }
-
-    private bool CanDrawNumber() => _availableNumbers.Count > 0 && !_isDrawing;
-
-    private bool _isDrawing;
-    
-    /// <summary>
-    /// 抽選中かどうかを示すフラグ。
-    /// </summary>
-    public bool IsDrawing
-    {
-        get => _isDrawing;
-        set { if (_isDrawing == value) return; _isDrawing = value; OnPropertyChanged(); ((RelayCommand)DrawNumberCommand).RaiseCanExecuteChanged(); }
     }
 
     /// <summary>
@@ -143,29 +159,19 @@ public class BingoViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// 利用可能な番号からランダムに一つ選び、状態を更新します。
-    /// </summary>
-    private void DrawNumber()
-    {
-        if (_availableNumbers.Count == 0 || _isDrawing) return;
-        StartDrawAnimation();
-    }
-
-    /// <summary>
     /// ウィンドウサイズに合わせて行数やセルサイズを再計算します。
     /// </summary>
     /// <param name="width">利用可能幅。</param>
     /// <param name="height">利用可能高さ。</param>
     public void UpdateLayout(double width, double height)
     {
-        double horizontalMargin = 80; // approximate outer margins
-        double verticalReserved = 320; // title + current number area
+        double horizontalMargin = 80;
+        double verticalReserved = 320;
         double availableWidth = Math.Max(200, width - horizontalMargin);
         double availableHeight = Math.Max(200, height - verticalReserved);
-        double spacing = 6; // item margin approximation
-        double columnPadding = 12; // internal padding per column
+        double spacing = 6;
+        double columnPadding = 12;
 
-        // Evaluate both layout options (5 or 10 rows)
         (int rows, int cols, double cellSize) Eval(int r)
         {
             int colsNeeded = (int)Math.Ceiling(75.0 / r);
@@ -174,27 +180,36 @@ public class BingoViewModel : INotifyPropertyChanged
             double size = Math.Max(24, Math.Min(cellSizeHeight, cellSizeWidth));
             return (r, colsNeeded, size);
         }
+
         var opt5 = Eval(5);
         var opt10 = Eval(10);
         var chosen = opt5.cellSize > opt10.cellSize ? opt5 : opt10;
+
         if (chosen.rows != _rowsPerColumn)
         {
             _rowsPerColumn = chosen.rows;
             RebuildDynamicColumns();
         }
+
         NumberCellSize = chosen.cellSize;
         NumberFontSize = Math.Clamp(chosen.cellSize * 0.42, 12, 48);
     }
 
-    /// <summary>
-    /// 行数設定に応じて動的列コレクションを再構築します。
-    /// </summary>
+    private bool CanDrawNumber() => _availableNumbers.Count > 0 && !_isDrawing;
+
+    private void DrawNumber()
+    {
+        if (_availableNumbers.Count == 0 || _isDrawing) return;
+        StartDrawAnimation();
+    }
+
     private void RebuildDynamicColumns()
     {
         DynamicColumns.Clear();
         int rows = _rowsPerColumn;
         int total = AllNumbers.Count;
         int colCount = (int)Math.Ceiling(total / (double)rows);
+
         for (int c = 0; c < colCount; c++)
         {
             int startIndex = c * rows;
@@ -203,15 +218,16 @@ public class BingoViewModel : INotifyPropertyChanged
             {
                 Label = AllNumbers[startIndex].Value.ToString("00") + "-" + AllNumbers[endIndex].Value.ToString("00")
             };
-            for (int i = startIndex; i <= endIndex; i++) col.Numbers.Add(AllNumbers[i]);
+            for (int i = startIndex; i <= endIndex; i++)
+            {
+                col.Numbers.Add(AllNumbers[i]);
+            }
             DynamicColumns.Add(col);
         }
+
         OnPropertyChanged(nameof(DynamicColumns));
     }
 
-    /// <summary>
-    /// 全番号・履歴・UI 状態を初期化し、新しいゲームを開始します。
-    /// </summary>
     private void Reset()
     {
         _availableNumbers.Clear();
@@ -228,12 +244,12 @@ public class BingoViewModel : INotifyPropertyChanged
             AllNumbers.Add(bn);
         }
 
-        // Populate tens groups (legacy, can be removed later)
+        // 10刻みグループ作成
         int current = 1;
         while (current <= 75)
         {
             int start = current;
-            int end = Math.Min(((current - 1) / 10 + 1) * 10, 75); // end of tens or 75
+            int end = Math.Min(((current - 1) / 10 + 1) * 10, 75);
             var group = new BingoNumberGroup
             {
                 Label = start.ToString("00") + "-" + end.ToString("00")
@@ -246,94 +262,33 @@ public class BingoViewModel : INotifyPropertyChanged
             current = end + 1;
         }
 
-        // Populate vertical bingo columns (1-15,16-30,...)
+        // BINGO列（1-15, 16-30, ...）作成
         int colStart = 1;
         while (colStart <= 75)
         {
             int colEnd = Math.Min(colStart + 14, 75);
-            var col = new BingoNumberColumn { Label = colStart + "-" + colEnd }; // label, could be B,I,N,G,O
-            for (int n = colStart; n <= colEnd; n++) col.Numbers.Add(AllNumbers[n - 1]);
+            var col = new BingoNumberColumn { Label = colStart + "-" + colEnd };
+            for (int n = colStart; n <= colEnd; n++)
+            {
+                col.Numbers.Add(AllNumbers[n - 1]);
+            }
             Columns.Add(col);
             colStart = colEnd + 1;
         }
 
-        // Build initial dynamic columns
         RebuildDynamicColumns();
-
         CurrentNumber = null;
         ((RelayCommand)DrawNumberCommand).RaiseCanExecuteChanged();
-        UpdateLayout(1000, 800); // initial sizing
+        UpdateLayout(1000, 800);
     }
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler? PropertyChanged;
+
     /// <summary>
     /// プロパティ変更イベントを発火します。
     /// </summary>
     /// <param name="propertyName">変更されたプロパティ名。</param>
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-}
-
-/// <summary>
-/// 10刻みの番号グループを表します。
-/// </summary>
-public class BingoNumberGroup
-{
-    /// <summary>グループを識別するラベル。</summary>
-    public string Label { get; set; } = string.Empty;
-    /// <summary>所属する番号リスト。</summary>
-    public ObservableCollection<BingoNumber> Numbers { get; } = [];
-}
-
-/// <summary>
-/// 列単位で番号を保持するモデル。
-/// </summary>
-public class BingoNumberColumn
-{
-    /// <summary>列のラベル (範囲や BINGO 文字)。</summary>
-    public string Label { get; set; } = string.Empty;
-    /// <summary>列に含まれる番号。</summary>
-    public ObservableCollection<BingoNumber> Numbers { get; } = [];
-}
-
-/// <summary>
-/// 単一のビンゴ番号と抽選状態を表すモデル。
-/// </summary>
-/// <param name="value">ビンゴ番号。</param>
-public class BingoNumber(int value) : INotifyPropertyChanged
-{
-    private bool _isDrawn;
-    /// <summary>番号の数値。</summary>
-    public int Value { get; } = value;
-    /// <summary>抽選済みかどうか。</summary>
-    public bool IsDrawn
-    {
-        get => _isDrawn;
-        set { if (_isDrawn == value) return; _isDrawn = value; OnPropertyChanged(); }
-    }
-    /// <inheritdoc />
-    public event PropertyChangedEventHandler? PropertyChanged;
-    /// <summary>プロパティ変更通知を送信します。</summary>
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-}
-
-/// <summary>
-/// シンプルな <see cref="ICommand"/> 実装。
-/// </summary>
-public class RelayCommand : ICommand
-{
-    private readonly Action _execute;
-    private readonly Func<bool>? _canExecute;
-    /// <summary>
-    /// 実行デリゲートと条件デリゲートでコマンドを初期化します。
-    /// </summary>
-    public RelayCommand(Action execute, Func<bool>? canExecute = null) { _execute = execute ?? throw new ArgumentNullException(nameof(execute)); _canExecute = canExecute; }
-    /// <inheritdoc />
-    public bool CanExecute(object? parameter) => _canExecute == null || _canExecute();
-    /// <inheritdoc />
-    public void Execute(object? parameter) => _execute();
-    /// <inheritdoc />
-    public event EventHandler? CanExecuteChanged;
-    /// <summary>CanExecute の変更を通知します。</summary>
-    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/WpfBingo/ViewModels/RelayCommand.cs
+++ b/WpfBingo/ViewModels/RelayCommand.cs
@@ -1,0 +1,37 @@
+using System.Windows.Input;
+
+namespace WpfBingo.ViewModels;
+
+/// <summary>
+/// シンプルな <see cref="ICommand"/> 実装。
+/// </summary>
+public class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    /// <summary>
+    /// 実行デリゲートと条件デリゲートでコマンドを初期化します。
+    /// </summary>
+    /// <param name="execute">コマンド実行時のアクション。</param>
+    /// <param name="canExecute">実行可否を判定する関数。</param>
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    /// <inheritdoc />
+    public bool CanExecute(object? parameter) => _canExecute is null || _canExecute();
+
+    /// <inheritdoc />
+    public void Execute(object? parameter) => _execute();
+
+    /// <inheritdoc />
+    public event EventHandler? CanExecuteChanged;
+
+    /// <summary>
+    /// CanExecute の変更を通知します。
+    /// </summary>
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WpfBingo/Views/MainWindow.xaml
+++ b/WpfBingo/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WpfBingo.MainWindow"
+<Window x:Class="WpfBingo.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -83,7 +83,7 @@
             <DoubleAnimation Storyboard.TargetName="OverlayNumberRotate" Storyboard.TargetProperty="Angle" From="0" To="720" Duration="0:0:1.2"/>
         </Storyboard>
 
-        <!-- Background animation patterns (use BgColorRect & effect shapes) -->
+        <!-- Background animation patterns -->
         <Storyboard x:Key="BackgroundAnimationPattern1">
             <ColorAnimation Storyboard.TargetName="BgColorRect" Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)" From="#F5F5F5" To="#FFE082" Duration="0:0:0.25" AutoReverse="True"/>
             <DoubleAnimation Storyboard.TargetName="BgRadialFlash" Storyboard.TargetProperty="Opacity" From="0" To="0.55" Duration="0:0:0.18" AutoReverse="True"/>
@@ -172,12 +172,10 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <!-- Background effect layer (behind content) -->
+        <!-- Background effect layer -->
         <Grid Grid.RowSpan="3" IsHitTestVisible="False" Panel.ZIndex="0">
             <Canvas Width="1000" Height="800">
-                <!-- Color rectangle for brush animation -->
                 <Rectangle x:Name="BgColorRect" Width="1000" Height="800" Fill="{StaticResource WindowBgBrush}"/>
-                <!-- Radial flash ellipse -->
                 <Ellipse x:Name="BgRadialFlash" Width="280" Height="280" Opacity="0" RenderTransformOrigin="0.5,0.5" Canvas.Left="360" Canvas.Top="260">
                     <Ellipse.Fill>
                         <RadialGradientBrush GradientOrigin="0.5,0.5" Center="0.5,0.5" RadiusX="0.5" RadiusY="0.5">
@@ -187,7 +185,6 @@
                     </Ellipse.Fill>
                     <Ellipse.RenderTransform><ScaleTransform ScaleX="0" ScaleY="0"/></Ellipse.RenderTransform>
                 </Ellipse>
-                <!-- Gradient sweep rectangle -->
                 <Rectangle x:Name="BgGradientSweep" Width="600" Height="900" Opacity="0" RenderTransformOrigin="0.5,0.5">
                     <Rectangle.Fill>
                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
@@ -198,7 +195,6 @@
                     </Rectangle.Fill>
                     <Rectangle.RenderTransform><TranslateTransform X="-1000" Y="0"/></Rectangle.RenderTransform>
                 </Rectangle>
-                <!-- Shimmer rectangle -->
                 <Rectangle x:Name="BgShimmer" Width="400" Height="900" Opacity="0" RenderTransformOrigin="0.5,0.5">
                     <Rectangle.Fill>
                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
@@ -210,14 +206,10 @@
                     </Rectangle.Fill>
                     <Rectangle.RenderTransform><TranslateTransform X="-800" Y="0"/></Rectangle.RenderTransform>
                 </Rectangle>
-                <!-- Pulse ring -->
                 <Ellipse x:Name="BgPulseRing" Width="260" Height="260" StrokeThickness="8" StrokeDashArray="2 4" Opacity="0" Canvas.Left="370" Canvas.Top="270" RenderTransformOrigin="0.5,0.5">
-                    <Ellipse.Stroke>
-                        <SolidColorBrush Color="#FFE082"/>
-                    </Ellipse.Stroke>
+                    <Ellipse.Stroke><SolidColorBrush Color="#FFE082"/></Ellipse.Stroke>
                     <Ellipse.RenderTransform><ScaleTransform ScaleX="0.3" ScaleY="0.3"/></Ellipse.RenderTransform>
                 </Ellipse>
-                <!-- Diagonal glow bar -->
                 <Rectangle x:Name="BgDiagonalGlow" Width="1400" Height="220" Opacity="0" Canvas.Left="-200" Canvas.Top="140" RenderTransformOrigin="0.5,0.5">
                     <Rectangle.Fill>
                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
@@ -253,14 +245,12 @@
                 <Button Command="{Binding ResetCommand}" Content="リセット" FontSize="18" FontWeight="Bold" Padding="30,15" Margin="10,0" Background="#F44336" Foreground="White" BorderThickness="0"/>
             </StackPanel>
         </Grid>
-        <!-- Grouped numbers (always fully visible) -->
+        <!-- Grouped numbers -->
         <Border Grid.Row="2" Margin="20" Background="White" BorderBrush="#E0E0E0" BorderThickness="1" CornerRadius="10">
             <Viewbox Stretch="Uniform" StretchDirection="DownOnly">
                 <ItemsControl ItemsSource="{Binding DynamicColumns}">
                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal" />
-                        </ItemsPanelTemplate>
+                        <ItemsPanelTemplate><StackPanel Orientation="Horizontal" /></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
@@ -268,11 +258,7 @@
                                 <StackPanel>
                                     <TextBlock Text="{Binding Label}" FontSize="16" FontWeight="Bold" Foreground="#1976D2" HorizontalAlignment="Center" Margin="0,0,0,6"/>
                                     <ItemsControl ItemsSource="{Binding Numbers}" ItemTemplate="{StaticResource GroupedNumberTemplate}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                                     </ItemsControl>
                                 </StackPanel>
                             </Border>
@@ -283,23 +269,12 @@
         </Border>
         <!-- Roulette Overlay -->
         <Grid x:Name="RouletteOverlay" Grid.RowSpan="3" Background="#E0FF9800" Visibility="Collapsed" IsHitTestVisible="False" Panel.ZIndex="90">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <!-- 中央のマスク（現在の番号が見える窓） -->
-            <Border HorizontalAlignment="Center" VerticalAlignment="Center" 
-                    Background="#FF9800" CornerRadius="40" 
-                    Width="500" Height="320" ClipToBounds="True">
-                <Border.Effect>
-                    <DropShadowEffect Color="#000000" Opacity="0.5" BlurRadius="40" ShadowDepth="10"/>
-                </Border.Effect>
+            <Border HorizontalAlignment="Center" VerticalAlignment="Center" Background="#FF9800" CornerRadius="40" Width="500" Height="320" ClipToBounds="True">
+                <Border.Effect><DropShadowEffect Color="#000000" Opacity="0.5" BlurRadius="40" ShadowDepth="10"/></Border.Effect>
                 <Canvas x:Name="RouletteCanvas" ClipToBounds="True">
-                    <StackPanel x:Name="RouletteStack" Orientation="Vertical" HorizontalAlignment="Center">
-                        <!-- 動的に番号を追加 -->
-                    </StackPanel>
+                    <StackPanel x:Name="RouletteStack" Orientation="Vertical" HorizontalAlignment="Center"/>
                 </Canvas>
             </Border>
-            <!-- 上下のグラデーションオーバーレイ（スロット機風） -->
             <Border HorizontalAlignment="Center" VerticalAlignment="Center" Width="500" Height="320" IsHitTestVisible="False">
                 <Grid>
                     <Border VerticalAlignment="Top" Height="80">
@@ -318,12 +293,11 @@
                             </LinearGradientBrush>
                         </Border.Background>
                     </Border>
-                    <!-- 中央のライン（停止位置の目印） -->
                     <Border VerticalAlignment="Center" Height="6" Background="#FFFFEB3B" Opacity="0.8"/>
                 </Grid>
             </Border>
         </Grid>
-        <!-- Overlay -->
+        <!-- Result Overlay -->
         <Grid x:Name="OverlayGrid" Grid.RowSpan="3" Background="#80000000" Visibility="Collapsed" Opacity="0" IsHitTestVisible="False" Panel.ZIndex="100">
             <Canvas x:Name="ConfettiCanvas"/>
             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">


### PR DESCRIPTION
WPFアプリをMVVM/DI構成でレイヤー分割・リファクタ

WPFビンゴアプリの構造を見直し、View・ViewModel・Model・DI/ホスティングの責務ごとにファイル・名前空間を分離しました。
- View: MainWindowをViews配下へ移動しx:Classも修正
- ViewModel: BingoViewModel, RelayCommandをViewModels配下へ分離
- Model: ビンゴ番号等のモデルをModels配下へ新設
- DI/起動: ServiceCollectionExtensions, WpfHostedServiceをHosting配下に新設し、DI登録・起動を一元化
- App.xaml.csの起動処理をHostedServiceベースに変更
これにより、MVVM+DI+レイヤー分離の構成となり、保守性・拡張性・テスト容易性が大幅に向上します。